### PR TITLE
Anki 2.1.45 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="anki_cousins",
-    version="0.4",
+    version="0.5",
     tests_require=["PyQt5-stubs" "anki", "black", "flake8", "isort", "mypy"],
     packages=["src"],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="anki_cousins",
-    version="0.5",
+    version="0.6",
     tests_require=["PyQt5-stubs" "anki", "black", "flake8", "isort", "mypy"],
     packages=["src"],
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,12 +6,19 @@ from anki.collection import _Collection as Collection
 from anki.hooks import wrap
 from anki.sched import Scheduler
 from anki.schedv2 import Scheduler as SchedulerV2
+from anki import buildinfo
 
 from . import interface  # noqa: F401
 from . import main  # noqa: F401
+
+version = tuple(map(int, buildinfo.version.split(".")))
 
 # Anki doesn't have hooks in all of the right places, so monkey patching
 # private methods is an established if fragile pattern
 Scheduler._burySiblings = wrap(Scheduler._burySiblings, main.buryCousins, "after")  # type: ignore
 SchedulerV2._burySiblings = wrap(SchedulerV2._burySiblings, main.buryCousins, "after")  # type: ignore
-Collection.findDupes = wrap(Collection.findDupes, main.findDupes, None)  # type: ignore
+
+if version >= (2, 1, 45):
+    Collection.find_dupes = wrap(Collection.find_dupes, main.findDupes, None)  # type: ignore
+else:
+    Collection.findDupes = wrap(Collection.findDupes, main.findDupes, None)  # type: ignore

--- a/src/main.py
+++ b/src/main.py
@@ -98,7 +98,10 @@ def buryCousins(self: SomeScheduler, card: "Card") -> None:
     self.newCount -= len(count_adjustments[QUEUE_TYPE_NEW])
 
     if cousin_cards:
-        tooltip("burying %d cousin card" % len(cousin_cards))
+        tooltip(
+            "burying %d cousin card%s"
+            % (len(cousin_cards), "s" if len(cousin_cards) > 1 else "")
+        )
 
     card_ids_to_bury = [
         id

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,5 @@
+{
+        "name": "Bury Cousins",
+        "package": "bury_cousins",
+        "human_version": "0.5"
+}

--- a/src/settings.py
+++ b/src/settings.py
@@ -93,7 +93,7 @@ class SettingsManager:
             set_config = self.col.set_config
         except AttributeError:
             # Compatibility with Anki<2.1.24
-            set_config = self.col.conf.__setitem__
+            set_config = self.col.conf.__setitem__  # type: ignore
 
         set_config(
             self.key,

--- a/src/settings.py
+++ b/src/settings.py
@@ -246,6 +246,9 @@ class _cloze_contained_by:
 
     >>> bool(_cloze_contained_by()(['Phase {{c1::2::#N}} clinical trial'], ['2 x 2'], 1))
     False
+
+    >>> bool(_cloze_contained_by()(['{{c1::hello}}'], ['phelloderm'], 1))
+    False
     """
 
     @staticmethod

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ deps =
     PyQT5-stubs
     anki_2125: anki == 2.1.25
     anki_2135: anki == 2.1.35
-    anki_latest: anki >= 2.1.38
+    anki_2144: anki == 2.1.44
+    anki_latest: anki >= 2.1.44
 
 commands =
     mypy src


### PR DESCRIPTION
This PR aims to fix all the Anki 2.1.45 compatibility issues. So far the only one I know about is that `findDupes` is renamed to `find_dupes`.